### PR TITLE
Use nvim_set_hl instead of vim.cmd in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,7 @@ use {
       group = FOO,
       pattern = 'typewriter-night',
       callback = function ()
-        vim.cmd[[
-          hi murmur_cursor_rgb guifg=#0a100d guibg=#ffee32
-        ]]
+        vim.api.nvim_set_hl(0, "murmur_cursor_rgb", { fg = "#0a100d", bg = "#ffee32" })
       end
     })
   end


### PR DESCRIPTION
The `nvim_set_hl` api function offers more flexibility in my opinion