### PR TITLE
feat: highlight current cursorword separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ use {
     }
 
     -- To create IDE-like no blinking diagnostic message with `cursor` scope. (should be paired with the callback above)
-    vim.api.nvim_create_autocmd({ 'CursorHold', 'InsertLeave' }, {
+    vim.api.nvim_create_autocmd('CursorHold', {
       group = FOO,
       pattern = '*',
       callback = function ()
@@ -71,7 +71,7 @@ use {
           -- If the window closes for any reason *other* than it being closed by a callback,
           -- make it triggerable again
           vim.api.nvim_create_autocmd("WinClosed", {
-            group = au,
+            group = FOO,
             buffer = buf,
             once = true,
             callback = function() vim.w.diag_shown = false end,

--- a/lua/murmur/init.lua
+++ b/lua/murmur/init.lua
@@ -1,11 +1,11 @@
-local A = require('murmur.utils.autocmd')
+local A = require("murmur.utils.autocmd")
+local H = require("murmur.utils.highlight")
 local M = {}
-vim.api.nvim_create_augroup('murmur.lua', { clear = true })
+vim.api.nvim_create_augroup("murmur.lua", { clear = true })
 ---------------------------------------------------------------------------------------------------
 
 local fn = vim.fn
 local api = vim.api
-
 
 local function matchdelete(clear_word)
   if clear_word then
@@ -15,8 +15,11 @@ local function matchdelete(clear_word)
     pcall(fn.matchdelete, vim.w.cursor_word_match_id)
     vim.w.cursor_word_match_id = nil
   end
+  if vim.w.cursor_current_match_id then
+    pcall(fn.matchdelete, vim.w.cursor_current_match_id)
+    vim.w.cursor_current_match_id = nil
+  end
 end
-
 
 local function matchstr(...)
   local ok, ret = pcall(fn.matchstr, ...)
@@ -26,25 +29,28 @@ local function matchstr(...)
   return ""
 end
 
-
 -------------------------------------------------------------------------------------------------------
 function M.setup(opts)
-  if not opts then opts = {} end
+  if not opts then
+    opts = {}
+  end
 
-  M.config_cursor_rgb = opts.cursor_rgb or { guifg = 'NONE', guibg = '#393939' }
-    if type(M.config_cursor_rgb) ~= 'table' then M.config_cursor_rgb = {} end
-    if type(M.config_cursor_rgb.guifg) ~= 'string' then M.config_cursor_rgb.guifg = 'NONE' end
-    if type(M.config_cursor_rgb.guibg) ~= 'string' then M.config_cursor_rgb.guibg = '#393939' end
+  H.setup(opts.cursor_rgb, opts.cursor_rgb_current)
+
   M.yank_blink = opts.yank_blink or { enabled = true, on_yank = nil }
-    if type(M.yank_blink) ~= 'table' then M.yank_blink = {} end
-    if type(M.yank_blink.enabled) ~= 'boolean' then M.yank_blink.enabled = true end
-    if type(M.yank_blink.on_yank) ~= 'table' then
-      M.yank_blink.on_yank = {
-        higroup = 'murmur_yank_hl',
-        timeout = 200,
-        on_visual = true
-      }
-    end
+  if type(M.yank_blink) ~= "table" then
+    M.yank_blink = {}
+  end
+  if type(M.yank_blink.enabled) ~= "boolean" then
+    M.yank_blink.enabled = true
+  end
+  if type(M.yank_blink.on_yank) ~= "table" then
+    M.yank_blink.on_yank = {
+      higroup = "murmur_yank_hl",
+      timeout = 200,
+      on_visual = true,
+    }
+  end
 
   M.cursor_rgb_always_use_config = opts.cursor_rgb_always_use_config or false
   M.max_len = opts.max_len or 20
@@ -54,15 +60,21 @@ function M.setup(opts)
   M.callbacks = opts.callbacks or {}
 
   A.create_autocmds()
+  H.create_highlights()
 end
 
-
 function M.matchadd(insert_mode)
-  if vim.fn.getbufinfo(vim.fn.bufnr())[1].linecount > M.disable_on_lines then return end
-  if vim.tbl_contains(M.exclude_filetypes, vim.bo.filetype) then return end
+  if vim.fn.getbufinfo(vim.fn.bufnr())[1].linecount > M.disable_on_lines then
+    return
+  end
+  if vim.tbl_contains(M.exclude_filetypes, vim.bo.filetype) then
+    return
+  end
 
   local column = api.nvim_win_get_cursor(0)[2] + 1 -- one-based indexing.
-    if insert_mode then column = column - 1 end
+  if insert_mode then
+    column = column - 1
+  end
   local line = api.nvim_get_current_line()
 
   -- get the cursor word.
@@ -73,10 +85,12 @@ function M.matchadd(insert_mode)
   local cursor_word = left .. right
 
   -- exit when on the same cursor word.
-  if cursor_word == vim.w.cursor_word then return end
+  if cursor_word == vim.w.cursor_word then
+    return
+  end
 
   for _, cb in ipairs(M.callbacks) do
-    if type(cb) == 'function' then
+    if type(cb) == "function" then
       cb()
     end
   end
@@ -89,12 +103,19 @@ function M.matchadd(insert_mode)
     return
   end
 
-  cursor_word = fn.escape(cursor_word, [[~"\.^$[]*]])
-  vim.w.cursor_word_match_id = fn.matchadd('murmur_cursor_rgb', [[\<]] .. cursor_word .. [[\>]], -1)
+  -- highlight matches not under the cursor
+  local pat = string.format([[\(%s\)\@!\&\V\<%s\>]], [[\k*\%#\k*]], cursor_word)
+  vim.w.cursor_word_match_id = vim.fn.matchadd("murmur_cursor_rgb", pat)
+
+  -- highlight the current word under the cursor
+  pat = string.format([[%s\&\V\<%s\>]], [[\k*\%#\k*]], cursor_word)
+  vim.w.cursor_current_match_id = vim.fn.matchadd("murmur_cursor_rgb_current", pat)
 end
 
 function M.matchdelete()
-  if vim.fn.getbufinfo(vim.fn.bufnr())[1].linecount > M.disable_on_lines then return end
+  if vim.fn.getbufinfo(vim.fn.bufnr())[1].linecount > M.disable_on_lines then
+    return
+  end
   matchdelete(true)
 end
 

--- a/lua/murmur/utils/autocmd.lua
+++ b/lua/murmur/utils/autocmd.lua
@@ -2,112 +2,107 @@ local M = {}
 ---------------------------------------------------------------------------------------------------
 local just_yank = false
 
-
 local function create_yank_blink()
-  -- recreate `default_yank_hl`.
-  vim.api.nvim_create_autocmd({ 'VimEnter', 'ColorScheme' }, {
-    group = 'murmur.lua',
-    pattern = '*',
-    callback = function ()
-      vim.cmd [[
-        hi murmur_yank_hl guifg=black guibg=#f0e130
-      ]]
-    end
-  })
-  -- main part.
-  vim.api.nvim_create_autocmd({ 'TextYankPost' }, {
-    group = 'murmur.lua',
-    pattern = '*',
-    callback = function ()
-      if not require('murmur').yank_blink.enabled then return end
-      if type(require('murmur').yank_blink.on_yank) == 'table' then
-        pcall(vim.highlight.on_yank, require('murmur').yank_blink.on_yank)
-        -- Ignore the possible `CursorMoved` after yanking and add the cursorword manually.
-        just_yank = true
-        vim.defer_fn(function ()
-          require('murmur').matchadd()
-          just_yank = false
-        end, 300)
-      end
-    end,
-  })
+	-- recreate `default_yank_hl`.
+	vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
+		group = "murmur.lua",
+		pattern = "*",
+		callback = function()
+			vim.api.nvim_set_hl(0, "murmur_yank_hl", { fg = "black", bg = "#f0e130" })
+		end,
+	})
+	-- main part.
+	vim.api.nvim_create_autocmd({ "TextYankPost" }, {
+		group = "murmur.lua",
+		pattern = "*",
+		callback = function()
+			if not require("murmur").yank_blink.enabled then
+				return
+			end
+			if type(require("murmur").yank_blink.on_yank) == "table" then
+				pcall(vim.highlight.on_yank, require("murmur").yank_blink.on_yank)
+				-- Ignore the possible `CursorMoved` after yanking and add the cursorword manually.
+				just_yank = true
+				vim.defer_fn(function()
+					require("murmur").matchadd()
+					just_yank = false
+				end, 300)
+			end
+		end,
+	})
 end
-
 
 local function create_murmur_cursor_rgb()
-  -- main part.
-  vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorHold' }, {
-    group = 'murmur.lua',
-    pattern = '*',
-    callback = function ()
-      if vim.fn.mode() ~= 'n' then return end
-      if -- move because of yank
-        just_yank
-      then return end
-      require('murmur').matchadd()
-    end
-  })
-  vim.api.nvim_create_autocmd({ 'CursorMovedI' }, {
-    group = 'murmur.lua',
-    pattern = '*',
-    callback = function () require('murmur').matchadd(true) end
-  })
-  vim.api.nvim_create_autocmd({ 'ModeChanged' }, {
-    group = 'murmur.lua',
-    pattern = '*',
-    callback = function ()
-      if vim.v.event.new_mode == 'v'
-        or vim.v.event.new_mode == 'V'
-        or vim.v.event.new_mode == ''
-        or (vim.v.event.new_mode == 'no' or vim.v.event.old_mode == 'no')
-      then
-        require('murmur').matchdelete()
-        return
-      end
-      if
-        vim.v.event.old_mode == 'v'
-        or vim.v.event.old_mode == 'V'
-        or vim.v.event.old_mode == ''
-      then
-        if just_yank then return end
-        require('murmur').matchadd()
-      end
-    end
-  })
-  vim.api.nvim_create_autocmd({ 'WinLeave' }, {
-    group = 'murmur.lua',
-    pattern = '*',
-    callback = function () require('murmur').matchdelete() end
-  })
-  -- try recreate `murmur_cursor_rgb` by config.
-  vim.api.nvim_create_autocmd({ 'VimEnter', 'ColorScheme' }, {
-    group = 'murmur.lua',
-    pattern = '*',
-    callback = function ()
-      if not require('murmur').cursor_rgb_always_use_config then return end
-
-      local str_template_hi_cmd = [[ hi murmur_cursor_rgb ]]
-      local config_cursor_rgb = require('murmur').config_cursor_rgb
-
-      if config_cursor_rgb.guifg then
-        str_template_hi_cmd = str_template_hi_cmd
-          .. string.format([[ guifg=%s ]], config_cursor_rgb.guifg)
-      end
-      if config_cursor_rgb.guibg then
-        str_template_hi_cmd = str_template_hi_cmd
-          .. string.format([[ guibg=%s ]], config_cursor_rgb.guibg)
-      end
-
-      vim.cmd(str_template_hi_cmd)
-    end
-  })
+	-- main part.
+	vim.api.nvim_create_autocmd({ "CursorMoved", "CursorHold" }, {
+		group = "murmur.lua",
+		pattern = "*",
+		callback = function()
+			if vim.fn.mode() ~= "n" then
+				return
+			end
+			if -- move because of yank
+				just_yank
+			then
+				return
+			end
+			require("murmur").matchadd()
+		end,
+	})
+	vim.api.nvim_create_autocmd({ "CursorMovedI" }, {
+		group = "murmur.lua",
+		pattern = "*",
+		callback = function()
+			require("murmur").matchadd(true)
+		end,
+	})
+	vim.api.nvim_create_autocmd({ "ModeChanged" }, {
+		group = "murmur.lua",
+		pattern = "*",
+		callback = function()
+			if
+				vim.v.event.new_mode == "v"
+				or vim.v.event.new_mode == "V"
+				or vim.v.event.new_mode == ""
+				or (vim.v.event.new_mode == "no" or vim.v.event.old_mode == "no")
+			then
+				require("murmur").matchdelete()
+				return
+			end
+			if vim.v.event.old_mode == "v" or vim.v.event.old_mode == "V" or vim.v.event.old_mode == "" then
+				if just_yank then
+					return
+				end
+				require("murmur").matchadd()
+			end
+		end,
+	})
+	vim.api.nvim_create_autocmd({ "WinLeave" }, {
+		group = "murmur.lua",
+		pattern = "*",
+		callback = function()
+			require("murmur").matchdelete()
+		end,
+	})
+	-- try recreate `murmur_cursor_rgb` by config.
+	vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
+		group = "murmur.lua",
+		pattern = "*",
+		callback = function()
+			if not require("murmur").cursor_rgb_always_use_config then
+				return
+			end
+			local hl = require("murmur.utils.highlight")
+			vim.defer_fn(function()
+				hl.create_highlights()
+			end, 150)
+		end,
+	})
 end
-
 
 function M.create_autocmds()
-  create_murmur_cursor_rgb()
-  create_yank_blink()
+	create_murmur_cursor_rgb()
+	create_yank_blink()
 end
-
 
 return M

--- a/lua/murmur/utils/highlight.lua
+++ b/lua/murmur/utils/highlight.lua
@@ -1,0 +1,68 @@
+local M = {}
+
+M.config = {}
+
+function M.get(hlgroup_name, attr)
+	local hlgroup_ID = vim.fn.synIDtrans(vim.fn.hlID(hlgroup_name))
+	local hex = vim.fn.synIDattr(hlgroup_ID, attr)
+	return hex ~= "" and hex or "NONE"
+end
+
+function M.setup(all, current)
+	if all then
+		M.config.all = all
+	elseif M.config.all then
+		all = M.config.all
+	end
+	if current then
+		M.config.current = current
+	elseif M.config.current then
+		current = M.config.current
+	end
+	if type(all) == table then
+		if type(all.guibg) ~= "string" then
+			all.bg = "#393939"
+		elseif all.guibg:sub(1, 1) ~= "#" and vim.fn.hlexists(all.guibg) == 1 then
+			all.bg = M.get(all.guibg, "guibg")
+		end
+		if type(all.guifg) ~= "string" then
+			all.fg = "NONE"
+		elseif all.guifg:sub(1, 1) ~= "#" and vim.fn.hlexists(all.guifg) == 1 then
+			all.fg = M.get(all.guifg, "guifg")
+		end
+	elseif type(all) == "string" and vim.fn.hlexists(all) == 1 then
+		all = { link = all }
+	else
+		all = { fg = "NONE", bg = "#393939" }
+	end
+
+	if type(current) == "table" then
+		if type(current.guibg) ~= "string" then
+			current.bg = "#393939"
+		elseif current.guibg:sub(1, 1) ~= "#" and vim.fn.hlexists(current.guibg) == 1 then
+			current.bg = M.get(current.guibg, "guibg")
+		end
+		if type(current.guifg) ~= "string" then
+			current.fg = "NONE"
+		elseif current.guifg:sub(1, 1) ~= "#" and vim.fn.hlexists(current.guifg) == 1 then
+			current.fg = M.get(current.guifg, "guifg")
+		end
+	elseif type(current) == "string" and vim.fn.hlexists(current) == 1 then
+		current = { link = current }
+	else
+		current = all
+	end
+	M.all = all
+	M.current = current
+end
+
+function M.create_highlights()
+	if M.all then
+		vim.api.nvim_set_hl(0, "murmur_cursor_rgb", M.all)
+	end
+	if M.current then
+		vim.api.nvim_set_hl(0, "murmur_cursor_rgb_current", M.current)
+	end
+end
+
+return M


### PR DESCRIPTION
Adds the ability to highlight the currently hovered cursor word differently from others. Also allows highlight group linking, so groups can be specified either with a table:

```lua
cursor_rgb = {
  guifg = "#ffffff", -- property as hex color,
  guibg = "Visual" -- link property to other hlgroup
}
```
or
```lua
cursor_rgb = "Visual" -- link directly to an hlgroup
```

Also some small fixes to my earlier PR - InsertLeave is actually not necessary and can lead to old diagnostics still being shown, though it does make the popup appear faster. 